### PR TITLE
Allow arbitrary amount of servers in vrrp instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,19 @@ Note: Name of the servers must match names in the inventory.
   vars:
     keepalived_enable_vrrp_firewall: true
     keepalived_vrrpinstances:
-      - name: mygroup
-        master: server1
-        masterif: eth0
-        masterpriorityanchor: 200
-        slave1: server2
-        slave1if: eth0
-        slave1priorityanchor: 199
-        slave2: server3
-        slave2if: eth0
-        slave2priorityanchor: 199
+      - name: "mygroup"
+        master: "server1"
         routerid: 1
+        servers:
+          server1:
+            interface: "eth0"
+            priority: 200
+          server1:
+            interface: "eth0"
+            priority: 199
+          server2:
+            interface: "ens192"
+            priority: 198
         vips:
           - 192.168.8.222
   roles:

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Note: Name of the servers must match names in the inventory.
           server1:
             interface: "eth0"
             priority: 200
-          server1:
+          server2:
             interface: "eth0"
             priority: 199
-          server2:
+          server3:
             interface: "ens192"
             priority: 198
         vips:

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -46,20 +46,16 @@ vrrp_script chk_{{ instance['name'] }} {
 {% endfor %}
 
 {% for instance in keepalived_vrrpinstances %}
-vrrp_instance {{ instance['name'] }}{
-{% if ansible_fqdn == instance['master'] %}
+vrrp_instance {{ instance['name'] }} {
+{% if instance.servers[ansible_fqdn] is defined %}
+{% set server = instance.servers[ansible_fqdn] %}
+{% if ansible_fqdn == instance.master %}
   state MASTER
-  interface {{ instance['masterif'] }}
-  priority {{ instance['masterpriorityanchor'] }}
-{% elif ansible_fqdn == instance['slave1'] %}
+{% else %}
   state BACKUP
-  interface {{ instance['slave1if'] }}
-  priority {{ instance['slave1priorityanchor']|int - 1 }}
-{% elif ansible_fqdn == instance['slave2'] %}
-  state BACKUP
-  interface {{ instance['slave2if'] }}
-  priority {{ instance['slave2priorityanchor']|int - 2 }}
 {% endif %}
+  interface {{ server.interface }}
+  priority {{ server.priority }}
   virtual_router_id {{ instance['routerid'] }}
 {% if instance['advertint'] is defined %}
   advert_int {{ instance['advertint'] }}
@@ -84,4 +80,5 @@ vrrp_instance {{ instance['name'] }}{
 {% endfor %}
   }
 }
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
Because:
- The current implementation hardcodes the server count to 2+1
- It is possible there might be more servers in other setups

This commit:
- Changes the hardcoded master and slaves to a dynamic object 'servers'

Currently, the name of the master server is recorded twice. Once directly in the instance configuration and once in the server list. One might consider to add a boolean flag to the server configuration instead. The latter might more likely result in the master getting overlooked, though.